### PR TITLE
Add early exit conditions and create system image script

### DIFF
--- a/gen_esp32part.py
+++ b/gen_esp32part.py
@@ -20,8 +20,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import print_function, division
 from __future__ import unicode_literals
+
 import argparse
 import os
 import re
@@ -249,6 +251,8 @@ class PartitionTable(list):
 
 class PartitionDefinition(object):
     MAGIC_BYTES = b"\xAA\x50"
+    ZERO_BYTES = b"\x00\x00"
+    FF_BYTES = b"\xFF\xFF"
 
     ALIGNMENT = {
         APP_TYPE: 0x10000,
@@ -472,6 +476,13 @@ def main():
     secure = args.secure
     offset_part_table = int(args.offset, 0)
     input = args.input.read()
+
+    # if the data is 0x00:0x00 or 0xff:0xff
+    if input[0:2] == PartitionDefinition.ZERO_BYTES or input[0:2] == PartitionDefinition.FF_BYTES:
+        # This looks empty flash so we cannot read it.
+        # exit with a failure
+        exit(3)
+
     input_is_binary = input[0:2] == PartitionDefinition.MAGIC_BYTES
     if input_is_binary:
         status("Parsing binary partition input...")
@@ -534,4 +545,6 @@ if __name__ == '__main__':
         main()
     except InputError as e:
         print(e, file=sys.stderr)
-        sys.exit(2)
+        exit(2)
+
+    exit(0)

--- a/scripts/create_sys_img.sh
+++ b/scripts/create_sys_img.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+function are_sizes_same {
+  size_str1="$1"
+  size_str2="$2"
+
+  size1_bytes=$(convert_to_bytes "$size_str1")
+  size2_bytes=$(convert_to_bytes "$size_str2")
+
+  if [ "$size1_bytes" -eq "$size2_bytes" ]; then
+    return 0  # sizes are equal, return true
+  else
+    return 1  # sizes are not equal, return false
+  fi
+}
+
+function convert_to_bytes {
+  size_str="$1"
+
+  # Determine the multiplier based on the suffix
+  if [[ $size_str == *'M'* ]]; then
+    multiplier=1048576  # 1024^2
+  elif [[ $size_str == *'K'* ]]; then
+    multiplier=1024
+  else
+    multiplier=1
+  fi
+
+  # Remove the suffix (if any) to get the numeric part
+  size=${size_str//[!0-9]/}
+
+  # Calculate the size in bytes
+  size_bytes=$((size * multiplier))
+
+  echo $size_bytes
+}
+
+while getopts p:b:c: flag
+	do
+	    case "${flag}" in
+	        c) CHIP=${OPTARG};;
+	        p) PORT=${OPTARG};;
+	        b) BAUD=${OPTARG};;
+	        *) echo "bad flag -${flag}"
+	    esac
+	done
+if [[ -z "$PORT" ]]; then
+	if [[ -z "${ESPPORT}" ]]; then
+		PORT="/dev/ttyUSB0"
+	else
+		PORT="${ESPPORT}"
+	fi
+fi
+
+if [[ -z "$BAUD" ]]; then
+	if [[ -z "${ESPBAUD}" ]]; then
+		BAUD="921600"
+	else
+		BAUD="${ESPBAUD}"
+	fi
+fi
+
+if [[ -z "$CHIP" ]]; then
+	if [[ -z "${ESPCHIP}" ]]; then
+		CHIP="esp32"
+	else
+		CHIP="${ESPCHIP}"
+	fi
+fi
+
+#esptool.py --chip $CHIP -b 115200 -p $PORT read_flash 0x8000 0xc00 ptable.img
+
+#GEN_STR=$(./gen_esp32part.py ./ptable.img)
+GEN_STR=$(./gen_esp32part.py images/partition-table.bin)
+status=$?
+
+SYS_IMG="images/sys.img"
+
+# Check if the command was successful
+if [ $status -eq 0 ]; then
+    PART_SIZE=$(echo -e "${GEN_STR}" | grep vfs | awk -F',' '{print $5}')
+    # see if there is a file called images/sys.img and if there is
+    # how big is it?
+    if [ -f "$SYS_IMG" ]; then
+      # Get the size of the file using wc (word count) utility in bytes
+      file_size_bytes=$(wc -c <"$SYS_IMG")
+
+      if are_sizes_same "${file_size_bytes}" "${PART_SIZE}" ; then
+        echo "File sizes are the same."
+        exit 0
+      else
+        echo "File sizes are different, we need to deal with it"
+        # rm the file
+        rm "${SYS_IMG}"
+      fi
+    fi
+
+    dd if=/dev/zero of="${SYS_IMG}" bs=1 count=0 count="${PART_SIZE}"
+    mkfs.fat -F 12 -f 1 -S 4096 -r 512 -s 1 -n 'ROOT' "${SYS_IMG}"
+    exit 0
+else
+    echo "Command failed with status $status."
+    exit 1
+fi


### PR DESCRIPTION
Modified 'gen_esp32part.py' to add early exit conditions if the input data reads as empty, enhancing runtime efficiency. Also, a new script 'create_sys_img.sh' has been added, which checks if file sizes are the same before running bundling commands, and generates system images. It includes functions to convert storage sizes and check their equivalences.